### PR TITLE
Avoid including ntt_gpu/ntt_ffp.cuh

### DIFF
--- a/include/cufhe.h
+++ b/include/cufhe.h
@@ -39,9 +39,10 @@
 
 #include "../thirdparties/TFHEpp/include/tfhe++.hpp"
 #include "details/allocator.h"
-#include "ntt_gpu/ntt_ffp.cuh"
 
 namespace cufhe {
+class FFP;
+
 using namespace TFHEpp;
 
 /*****************************

--- a/test/test_cmux.cc
+++ b/test/test_cmux.cc
@@ -22,6 +22,7 @@
 
 // Include these two files for GPU computing.
 #include <include/cufhe_gpu.cuh>
+#include <include/ntt_gpu/ntt_ffp.cuh>
 using namespace cufhe;
 
 #include <iostream>


### PR DESCRIPTION
to allow compilation by ordinary C++ compilers, not by nvcc.